### PR TITLE
Enable pipeline updates

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -138,13 +138,6 @@ func ReadPipeline(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdatePipeline(d *schema.ResourceData, meta interface{}) error {
-	// Buildkite apparently lacks an update API endpoint. I've contacted
-	// them to see what the deal is with that, but for now we'll just
-	// fail here.
-	return fmt.Errorf(
-		"Buildkite does not currently support updates. To continue, make this change manually in the Buildkite UI.",
-	)
-
 	client := meta.(*Client)
 	slug := d.Id()
 


### PR DESCRIPTION
The Buildkite Pipelines API now supports [updating via PATCH](https://buildkite.com/docs/api/pipelines#update-a-pipeline)
