### PR TITLE
provider_settings are usually string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: trusty
+sudo: false
+language: go
+go:
+- 1.8.1
+- tip
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - go: tip

--- a/buildkite/provider_test.go
+++ b/buildkite/provider_test.go
@@ -1,0 +1,38 @@
+package buildkite
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"buildkite": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("BUILDKITE_ORGANIZATION"); v == "" {
+		t.Fatal("BUILDKITE_ORGANIZATION must be set for acceptance tests")
+	}
+	if v := os.Getenv("BUILDKITE_API_TOKEN"); v == "" {
+		t.Fatal("BUILDKITE_API_TOKEN must be set for acceptance tests")
+	}
+}

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -77,7 +77,7 @@ func resourcePipeline() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeBool,
+					Type: schema.TypeString,
 				},
 			},
 			"webhook_url": &schema.Schema{
@@ -157,7 +157,7 @@ type Pipeline struct {
 	Description         string            `json:"description,omitempty"`
 	BranchConfiguration string            `json:"branch_configuration,omitempty"`
 	Provider            BuildkiteProvider `json:"provider,omitempty"`
-	ProviderSettings    map[string]bool   `json:"provider_settings,omitempty"`
+	ProviderSettings    map[string]string `json:"provider_settings,omitempty"`
 	Steps               []Step            `json:"steps"`
 }
 
@@ -295,9 +295,9 @@ func preparePipelineRequestPayload(d *schema.ResourceData) *Pipeline {
 	for k, vI := range d.Get("env").(map[string]interface{}) {
 		req.Environment[k] = vI.(string)
 	}
-	req.ProviderSettings = map[string]bool{}
+	req.ProviderSettings = map[string]string{}
 	for k, vI := range d.Get("provider_settings").(map[string]interface{}) {
-		req.ProviderSettings[k] = vI.(bool)
+		req.ProviderSettings[k] = vI.(string)
 	}
 
 	stepsI := d.Get("step").([]interface{})

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -1,0 +1,48 @@
+package buildkite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPipeline_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPipeline_basic,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						ms := s.RootModule()
+						rs := ms.Resources["buildkite_pipeline.test"]
+						if rs == nil {
+							return fmt.Errorf("no state for buildkite_pipeline.test")
+						}
+						if got, want := rs.Primary.Attributes["slug"], "tf-acc-basic"; got != want {
+							return fmt.Errorf("incorrect slug %s; want %s", got, want)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+const testAccPipeline_basic = `
+resource "buildkite_pipeline" "test" {
+  name = "tf-acc-basic"
+  repository = "git@github.com:saymedia/terraform-provider-buildkite.git"
+  default_branch = "master"
+
+  step {
+    type = "script"
+    name = "test"
+    command = "echo 'Hello World'"
+  }
+}
+`


### PR DESCRIPTION
For example:
```
"provider_settings.%": "3",
--
  | "provider_settings.pull_request_branch_filter_configuration": "",
  | "provider_settings.repository": "x/y",
  | "provider_settings.trigger_mode": "code",
```
fails currently with:

```

* buildkite_pipeline.web_deploy_harnesses: 1 error(s) occurred:
--
  |  
  | * buildkite_pipeline.web_deploy_harnesses: unexpected EOF
  | panic: interface conversion: interface {} is string, not bool
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite:
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: goroutine 32 [running]:
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: github.com/saymedia/terraform-buildkite/buildkite.preparePipelineRequestPayload(0xc420207a40, 0x16)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/home/ubuntu/go/src/github.com/saymedia/terraform-buildkite/buildkite/resource_pipeline.go:300 +0x11a0
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: github.com/saymedia/terraform-buildkite/buildkite.UpdatePipeline(0xc420207a40, 0xa618a0, 0xc42026d7c0, 0x0, 0x0)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/home/ubuntu/go/src/github.com/saymedia/terraform-buildkite/buildkite/resource_pipeline.go:229 +0xbe
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc420256c60, 0xc4200fea50, 0xc420281220, 0xa618a0, 0xc42026d7c0, 0x1, 0x28, 0xc4202dd920)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/home/ubuntu/go/src/github.com/hashicorp/terraform/helper/schema/resource.go:192 +0x378
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc4202071f0, 0xc4200fea00, 0xc4200fea50, 0xc420281220, 0x7f63f3a774b0, 0x0, 0x0)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/home/ubuntu/go/src/github.com/hashicorp/terraform/helper/schema/provider.go:242 +0x9b
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Apply(0xc420213fe0, 0xc420280a00, 0xc4202978c0, 0x0, 0x0)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/home/ubuntu/go/src/github.com/hashicorp/terraform/plugin/resource_provider.go:488 +0x57
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: reflect.Value.call(0xc42001cba0, 0xc42000e480, 0x13, 0xab4719, 0x4, 0xc420040f20, 0x3, 0x3, 0xadab90, 0xc4201fcee8, ...)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/usr/local/go/src/reflect/value.go:434 +0x91f
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: reflect.Value.Call(0xc42001cba0, 0xc42000e480, 0x13, 0xc4201fcf20, 0x3, 0x3, 0xc4201fcf0c, 0x180001, 0x200000000)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/usr/local/go/src/reflect/value.go:302 +0xa4
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: net/rpc.(*service).call(0xc4202799c0, 0xc420279980, 0xc42027c188, 0xc420023d80, 0xc42026cec0, 0x9aab00, 0xc420280a00, 0x16, 0x9aab40, 0xc4202978c0, ...)
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/usr/local/go/src/net/rpc/server.go:387 +0x144
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: created by net/rpc.(*Server).ServeCodec
  | 2017/07/13 01:42:54 [DEBUG] plugin: terraform-provider-buildkite: 	/usr/local/go/src/net/rpc/server.go:481 +0x404
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalWriteState
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalApplyProvisioners
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalIf
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalWriteState
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalWriteDiff
  | 2017/07/13 01:42:54 [DEBUG] root: eval: *terraform.EvalApplyPost
  | 2017/07/13 01:42:54 [ERROR] root: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:
```

due to an incorrect conversion from `string` -> `bool`.