### PR TITLE
Fix reserved field name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- 1.8.1
+- 1.9.2
 - tip
 
 matrix:

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -17,10 +17,6 @@ func resourcePipeline() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"slug": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -162,7 +158,6 @@ type Pipeline struct {
 }
 
 type BuildkiteProvider struct {
-	Id         string                 `json:"id"`
 	Settings   map[string]interface{} `json:"settings"`
 	WebhookURL string                 `json:"webhook_url"`
 }
@@ -251,7 +246,6 @@ func DeletePipeline(d *schema.ResourceData, meta interface{}) error {
 
 func updatePipelineFromAPI(d *schema.ResourceData, p *Pipeline) {
 	d.SetId(p.Slug)
-	d.Set("id", p.Id)
 	d.Set("env", p.Environment)
 	d.Set("name", p.Name)
 	d.Set("description", p.Description)


### PR DESCRIPTION
`id` is now a reserved field name in Terraform.

see https://github.com/hashicorp/terraform/commit/67ceb1ab07acd55ebc0d7b6efb39019e73fd1888.

In the result, `terraform plan` fails with 
```
Error: provider.buildkite: Internal validation of the provider failed! This is always a bug
--
  | with the provider itself, and not a user issue. Please report
  | this bug:
  |  
  | 1 error(s) occurred:
  |  
  | * resource buildkite_pipeline: id is a reserved field name
```

This commit fixes that. I'm not sure if `pipeline_id` is the best name for that, so I'm happy to change it. 

